### PR TITLE
Don't include closing } when using 'if' target

### DIFF
--- a/src/main/java/com/julienphalip/ideavim/functiontextobj/FunctionTextObj.java
+++ b/src/main/java/com/julienphalip/ideavim/functiontextobj/FunctionTextObj.java
@@ -84,13 +84,16 @@ public class FunctionTextObj implements VimExtension {
             int endOffset = method.getTextRange().getEndOffset();
 
             if (!around) {
+                Mode operationMode = operatorArguments.component3();
+                boolean isVisual = operationMode instanceof Mode.VISUAL;
+
                 PsiElement body = findFunctionBody(method);
                 if (body != null) {
                     startOffset = body.getTextRange().getStartOffset();
                     endOffset = body.getTextRange().getEndOffset();
                     if (usesBraces(body)) {
                         startOffset += 1;
-                        endOffset -= 1;
+                        endOffset -= isVisual ? 1 : 2;
                     }
                 }
             }


### PR DESCRIPTION
Addresses issue https://github.com/jphalip/ideavim-functiontextobj/issues/6 by varying the `endOffset` based on the operation mode.