### PR TITLE
Added non conflicting mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ using the Jetbrains language plugins:
 Don't like the default `f` mapping? You can remap the text objects in your
 `.ideavimrc`:
 
-```
+```vimscript
 " Use 'm' instead
-map im <Plug>InnerFunction
-map am <Plug>OuterFunction
+omap im <Plug>InnerFunction
+omap am <Plug>OuterFunction
+vmap im <Plug>InnerFunction
+vmap am <Plug>OuterFunction
 ```
 <!-- Plugin description end -->


### PR DESCRIPTION
I was initially using your suggested mapping to use "m" instead of "f":
```vimscript
" Use 'm' instead
map im <Plug>InnerFunction
map am <Plug>OuterFunction
```
The problem was that when I was in normal mode and wanted to switch to insert mode in order to write something, when I pressed "i" or "a", there was an unpleasant pause because IdeaVim waits is an "m" is added, so it can apply the mappings.
By limiting the mappings to operator, visual and select mode, the problem is gone and the usage is much more pleasant:
```vimscript
" Use 'm' instead
omap im <Plug>InnerFunction
omap am <Plug>OuterFunction
vmap im <Plug>InnerFunction
vmap am <Plug>OuterFunction
```

Thanks a lot for your effort developing this plugin. It was a game changer for me, I was using custom mappings to emulate the same but they only worked for Java and do not include method annotations.

Regards
Ricardo